### PR TITLE
Config: Remove `libunwind` dependency

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -2,7 +2,6 @@ menuconfig LIBCXX
     bool "libcxx - C++ standard library"
 	select LIBNOLIBC if !HAVE_LIBC
 	select LIBCXXABI
-	select LIBUNWIND
     default n
 
 if LIBCXX


### PR DESCRIPTION
There are two dependencies in `Config.uk`: `libcxxabi` and `libunwind`. But `libunwind` is already a dependency for `libcxxabi` so no need to include it.