### PR TITLE
include: Add location of features.h file for Musl

### DIFF
--- a/include/features.h
+++ b/include/features.h
@@ -34,7 +34,13 @@
 extern "C" {
 #endif
 
+#include <uk/config.h>
+
+#ifdef CONFIG_LIBMUSL
+#include <features.h>
+#else
 #include <sys/features.h>
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When using Musl, the `features.h` header is not
placed within the `sys/` directory, so the build fails.

Closes: #7.

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>