### PR TITLE
patches: Define strtoll_l and strtoull_l in `locale`

### DIFF
--- a/patches/0006-Add-xlocale-header-in-include-locale.patch
+++ b/patches/0006-Add-xlocale-header-in-include-locale.patch
@@ -1,0 +1,30 @@
+From accb12e021cc8f2750c606345dba19f7a66cc5ed Mon Sep 17 00:00:00 2001
+From: Stefan Jumarea <stefanjumarea02@gmail.com>
+Date: Sat, 29 Oct 2022 12:27:20 +0300
+Subject: [PATCH] Add xlocale header in include/locale
+
+The `include/locale` file needs `strtoll_l` and
+`strtoull_l`. They are defined as inlines in
+the `xlocale.h` header.
+
+Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>
+---
+ include/locale | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/include/locale b/include/locale
+index 3fe443002..550cbfda5 100644
+--- a/include/locale
++++ b/include/locale
+@@ -211,6 +211,8 @@ template <class charT> class messages_byname;
+ #pragma GCC system_header
+ #endif
+ 
++#include <xlocale.h>
++
+ _LIBCPP_PUSH_MACROS
+ #include <__undef_macros>
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
The `strtoull_l` and `strtoll_l` functions are needed by `locale` and are defined as inlines in `xlocale.h`.

Closes: #13 
Depends-on: #10 

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>