### PR TITLE
glue.c: Remove multiple definitions when using musl

### DIFF
--- a/glue.c
+++ b/glue.c
@@ -20,7 +20,9 @@
  */
 
 #include <nl_types.h>
+#include <uk/config.h>
 
+#ifndef CONFIG_LIBMUSL
 int catclose(nl_catd catalog)
 {
 	return 0;
@@ -36,5 +38,6 @@ char *catgets(nl_catd catalog, int set_number, int message_number,
 {
 	return 0;
 }
+#endif
 
 void *__dso_handle = (void *) &__dso_handle;


### PR DESCRIPTION
Musl provides the `catclose`, `catopen` and `catgets` functions, so when building `libcxx` with musl the linking fails.

This commit only defines the needed functions when `LIBMUSL` is not selected.

Closes: #16 

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>