### PR TITLE
patches: Define strtof_l and strtod_l in locale

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -86,6 +86,13 @@ CXXINCLUDES-$(CONFIG_LIBCXX) += -I$(LIBCXX_SRC)/func
 CXXINCLUDES-$(CONFIG_LIBCXX) += -I$(LIBCXX_SRC)/include
 CXXINCLUDES-$(CONFIG_LIBCXX) += -I$(LIBCXX_SRC)/utils
 
+ifeq ($(CONFIG_LIBMUSL),y)
+CINCLUDES-$(CONFIG_LIBCXX) += -I$(LIBCXX_SRC)/include/support/musl
+CXXINCLUDES-$(CONFIG_LIBCXX) += -I$(LIBCXX_SRC)/include/support/musl
+CINCLUDES-$(CONFIG_LIBCXX) += -I$(LIBCXX_SRC)/include/support/xlocale
+CXXINCLUDES-$(CONFIG_LIBCXX) += -I$(LIBCXX_SRC)/include/support/xlocale
+endif
+
 ################################################################################
 # Global flags
 ################################################################################

--- a/glue.c
+++ b/glue.c
@@ -20,7 +20,9 @@
  */
 
 #include <nl_types.h>
+#include <uk/config.h>
 
+#ifndef CONFIG_LIBMUSL
 int catclose(nl_catd catalog)
 {
 	return 0;
@@ -36,5 +38,6 @@ char *catgets(nl_catd catalog, int set_number, int message_number,
 {
 	return 0;
 }
+#endif
 
 void *__dso_handle = (void *) &__dso_handle;

--- a/include/features.h
+++ b/include/features.h
@@ -34,7 +34,13 @@
 extern "C" {
 #endif
 
+#include <uk/config.h>
+
+#ifdef CONFIG_LIBMUSL
+#include <features.h>
+#else
 #include <sys/features.h>
+#endif
 
 #ifdef __cplusplus
 }

--- a/patches/0006-Add-xlocale-header-in-include-locale.patch
+++ b/patches/0006-Add-xlocale-header-in-include-locale.patch
@@ -1,0 +1,30 @@
+From accb12e021cc8f2750c606345dba19f7a66cc5ed Mon Sep 17 00:00:00 2001
+From: Stefan Jumarea <stefanjumarea02@gmail.com>
+Date: Sat, 29 Oct 2022 12:27:20 +0300
+Subject: [PATCH] Add xlocale header in include/locale
+
+The `include/locale` file needs `strtoll_l` and
+`strtoull_l`. They are defined as inlines in
+the `xlocale.h` header.
+
+Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>
+---
+ include/locale | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/include/locale b/include/locale
+index 3fe443002..550cbfda5 100644
+--- a/include/locale
++++ b/include/locale
+@@ -211,6 +211,8 @@ template <class charT> class messages_byname;
+ #pragma GCC system_header
+ #endif
+ 
++#include <xlocale.h>
++
+ _LIBCPP_PUSH_MACROS
+ #include <__undef_macros>
+ 
+-- 
+2.25.1
+

--- a/patches/0007-Include-the-first-stddef-header-file.patch
+++ b/patches/0007-Include-the-first-stddef-header-file.patch
@@ -1,0 +1,26 @@
+From ba952bed536bce35464e5060bc563ff597fa6f3b Mon Sep 17 00:00:00 2001
+From: Stefan Jumarea <stefanjumarea02@gmail.com>
+Date: Sat, 29 Oct 2022 13:11:24 +0300
+Subject: [PATCH] Include the first `stddef.h` header file.
+
+Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>
+---
+ include/cstddef | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/cstddef b/include/cstddef
+index bd62d6db3..0baf2ad07 100644
+--- a/include/cstddef
++++ b/include/cstddef
+@@ -41,7 +41,7 @@ Types:
+ #endif
+ 
+ // Don't include our own <stddef.h>; we don't want to declare ::nullptr_t.
+-#include_next <stddef.h>
++#include <stddef.h>
+ #include <__nullptr>
+ 
+ _LIBCPP_BEGIN_NAMESPACE_STD
+-- 
+2.25.1
+

--- a/patches/0009-Add-strtof_l-strtod_l-header.patch
+++ b/patches/0009-Add-strtof_l-strtod_l-header.patch
@@ -1,0 +1,23 @@
+From c924cd52b45e2ab32368ca011a8f51a3e561d088 Mon Sep 17 00:00:00 2001
+From: Maria Sfiraiala <maria.sfiraiala@gmail.com>
+Date: Sun, 30 Oct 2022 20:00:39 +0200
+Subject: [PATCH] Add strtof_l, strtod_l header
+
+Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>
+---
+diff --git a/include/locale b/include/locale
+index c9ec7c36f582..9068f88117a7 100644
+--- a/include/locale
++++ b/include/locale
+@@ -817,6 +817,8 @@ __num_get_unsigned_integral(const char* __a, const char* __a_end,
+     return 0;
+ }
+ 
++#include <__strtonum_fallback.h>
++
+ template <class _Tp>
+ _LIBCPP_INLINE_VISIBILITY
+ _Tp __do_strtod(const char* __a, char** __p2);
+-- 
+2.25.1
+


### PR DESCRIPTION
When compiled for `AArch64`, apps using `libcxx` fail due to `strtof_l` and `strtod_l` not being defined in `include/locale`.

This PR adds a patch which includes the header that contains the definitions in `include/locale`.

It also modifies `Makefile.uk` to add the necessary file in the build process.

Depends on: #19 
Closes: #20 
Related to: #14

Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>