### PR TITLE
patches: Add patch with signature for `vasprintf`

### DIFF
--- a/patches/0011-Add-vasprintf-definition-needed-by-__bsd_locale_fall.patch
+++ b/patches/0011-Add-vasprintf-definition-needed-by-__bsd_locale_fall.patch
@@ -1,0 +1,48 @@
+From 47349ae4318953ea882108da36b679d23c73718d Mon Sep 17 00:00:00 2001
+From: Maria Sfiraiala <maria.sfiraiala@gmail.com>
+Date: Mon, 14 Nov 2022 11:35:49 +0200
+Subject: [PATCH] Add vasprintf definition needed by __bsd_locale_fallbacks.h
+
+Compilation step for __bsd_locale_fallbacks.h requires having a working
+definition of vasprintf. This symbol is defined in
+include/support/ibm/xlocale.h, however it wouldn't make sense for us
+to use headers made for ibm.
+
+This commit adds the needed function in include/support/musl.
+
+Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>
+---
+ include/__bsd_locale_fallbacks.h |  1 +
+ include/support/musl/xlocale.h | 20 ++++++++++++++++++++
+ 2 files changed, 21 insertions(+)
+
+diff --git a/include/__bsd_locale_fallbacks.h b/include/__bsd_locale_fallbacks.h
+index 9abd7e7e5ff4..3c31c2db3aa1 100644
+--- a/include/__bsd_locale_fallbacks.h
++++ b/include/__bsd_locale_fallbacks.h
+@@ -15,7 +15,8 @@
+
+ #include <stdlib.h>
+ #include <stdarg.h>
+ #include <memory>
++#include <support/musl/xlocale.h>
+ 
+ #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+ #  pragma GCC system_header
+diff --git a/include/support/musl/xlocale.h b/include/support/musl/xlocale.h
+index f564c87885ac..318a5a173e3f 100644
+--- a/include/support/musl/xlocale.h
++++ b/include/support/musl/xlocale.h
+@@ -49,6 +49,8 @@ static inline long double wcstold_l(const wchar_t *nptr, wchar_t **endptr,
+                                    locale_t) {
+   return wcstold(nptr, endptr);
+ }
+
++int vasprintf(char **strp, const char *fmt, va_list ap);
++
+ #ifdef __cplusplus
+ }
+ #endif // _LIBCPP_SUPPORT_MUSL_XLOCALE_H
+-- 
+2.25.1
+


### PR DESCRIPTION
Compilation step for `__bsd_locale_fallbacks.h` requires having a working definition of `vasprintf`. This symbol is defined in `include/support/ibm/xlocale.h`, however it wouldn't make sense for us to use headers made for `ibm`.

This PR provides a patch that adds the needed function in `include/support/musl`.

Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>