### PR TITLE
Makefile.uk: Add minimum compiler version check

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -39,6 +39,14 @@
 ################################################################################
 $(eval $(call addlib_s,libcxx,$(CONFIG_LIBCXX)))
 
+ifeq ($(CONFIG_LIBCXX),y)
+ifeq ($(call have_gcc),y)
+$(call error_if_gcc_version_lt,11,0)
+else ifeq ($(call have_clang),y)
+$(call error_if_clang_version_lt,10,0)
+endif
+endif
+
 ################################################################################
 # Sources
 ################################################################################


### PR DESCRIPTION
libcxx 14 relies on some C++ features that are only implemented starting from GCC 11 and Clang 10.
This change adds an explicit compiler version check to warn the user about this incompatibility.