### PR TITLE
Makefile.uk: Add -D_GNU_SOURCE to C++ flags

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -72,6 +72,9 @@ CXXINCLUDES-$(CONFIG_LIBCXX) += -I$(LIBCXX_BASE)/include
 CXXINCLUDES-$(CONFIG_LIBCXX) += -I$(LIBCXX_SRC)/src
 CXXINCLUDES-$(CONFIG_LIBCXX) += -I$(LIBCXX_SRC)/include
 
+# include/locale uses _GNU_SOURCE extensions from stdlib.h
+CXXFLAGS-$(CONFIG_LIBCXX) += -D_GNU_SOURCE
+
 ################################################################################
 # Global flags
 ################################################################################


### PR DESCRIPTION
libcxx uses strtod_l, strtof_l & strtold_l in include/locale, which are declared in stdlib.h only if _GNU_SOURCE is defined. GCC by default sets _GNU_SOURCE when compiling C++ for this exact reason, but clang does not, leading to compilation errors.
This change adds -D_GNU_SOURCE as a compilation flag to all C++ files when using libcxx.

In response to & fixes https://github.com/unikraft/app-helloworld-cpp/issues/18.