### PR TITLE
Update to LLVM 21.1.1

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -50,7 +50,7 @@ endif
 ################################################################################
 # Sources
 ################################################################################
-LIBCXX_VERSION=14.0.6
+LIBCXX_VERSION=21.1.1
 LIBCXX_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-$(LIBCXX_VERSION)/libcxx-$(LIBCXX_VERSION).src.tar.xz
 LIBCXX_PATCHDIR=$(LIBCXX_BASE)/patches
 $(eval $(call fetch,libcxx,$(LIBCXX_URL)))

--- a/include/__assertion_handler
+++ b/include/__assertion_handler
@@ -1,0 +1,55 @@
+#ifndef _LIBCPP___ASSERTION_HANDLER
+#define _LIBCPP___ASSERTION_HANDLER
+
+#if __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)
+#  include <__cxx03/__config>
+#  include <__cxx03/__verbose_abort>
+#  include <__cxx03/__verbose_trap>
+#else
+#  include <__config>
+#  include <__log_hardening_failure>
+#  include <__verbose_abort>
+#  include <__verbose_trap>
+#endif
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#  pragma GCC system_header
+#endif
+
+#if __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)
+
+// Keep the old implementation that doesn't support assertion semantics for backward compatibility with the frozen C++03
+// mode.
+#  if _LIBCPP_HARDENING_MODE == _LIBCPP_HARDENING_MODE_DEBUG
+#    define _LIBCPP_ASSERTION_HANDLER(message) _LIBCPP_VERBOSE_ABORT("%s", message)
+#  else
+#    define _LIBCPP_ASSERTION_HANDLER(message) _LIBCPP_VERBOSE_TRAP(message)
+#  endif // _LIBCPP_HARDENING_MODE == _LIBCPP_HARDENING_MODE_DEBUG
+
+#else
+
+#  if _LIBCPP_ASSERTION_SEMANTIC == _LIBCPP_ASSERTION_SEMANTIC_IGNORE
+#    define _LIBCPP_ASSERTION_HANDLER(message) ((void)0)
+
+#  elif _LIBCPP_ASSERTION_SEMANTIC == _LIBCPP_ASSERTION_SEMANTIC_OBSERVE
+#    define _LIBCPP_ASSERTION_HANDLER(message) _LIBCPP_LOG_HARDENING_FAILURE(message)
+
+#  elif _LIBCPP_ASSERTION_SEMANTIC == _LIBCPP_ASSERTION_SEMANTIC_QUICK_ENFORCE
+#    define _LIBCPP_ASSERTION_HANDLER(message) _LIBCPP_VERBOSE_TRAP(message)
+
+#  elif _LIBCPP_ASSERTION_SEMANTIC == _LIBCPP_ASSERTION_SEMANTIC_ENFORCE
+#    define _LIBCPP_ASSERTION_HANDLER(message) _LIBCPP_VERBOSE_ABORT("%s", message)
+
+#  else
+
+#    error _LIBCPP_ASSERTION_SEMANTIC must be set to one of the following values: \
+_LIBCPP_ASSERTION_SEMANTIC_IGNORE, \
+_LIBCPP_ASSERTION_SEMANTIC_OBSERVE, \
+_LIBCPP_ASSERTION_SEMANTIC_QUICK_ENFORCE, \
+_LIBCPP_ASSERTION_SEMANTIC_ENFORCE
+
+#  endif // _LIBCPP_ASSERTION_SEMANTIC == _LIBCPP_ASSERTION_SEMANTIC_IGNORE
+
+#endif // __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)
+
+#endif // _LIBCPP___ASSERTION_HANDLER

--- a/include/__config_site
+++ b/include/__config_site
@@ -30,8 +30,14 @@
 #undef __FLT16_MANT_DIG__
 #endif
 
+// PSTL backends
+#define _LIBCPP_PSTL_BACKEND_STD_THREAD
+
+// Hardening.
+#define _LIBCPP_HARDENING_MODE_DEFAULT 2
+
 #ifdef CONFIG_LIBMUSL
-#define _LIBCPP_HAS_MUSL_LIBC
+#define _LIBCPP_HAS_MUSL_LIBC 1
 #endif
 
 #endif // _LIBCPP___CONFIG_SITE

--- a/patches/0000-atomic_futex_syscall.patch
+++ b/patches/0000-atomic_futex_syscall.patch
@@ -1,27 +1,30 @@
-diff --git a/src/atomic.cpp b/src/atomic.cpp
---- a/src/atomic.cpp	
-+++ b/src/atomic.cpp	(date 1680772930656)
-@@ -19,6 +19,7 @@
- #include <unistd.h>
- #include <linux/futex.h>
- #include <sys/syscall.h>
-+#include <uk/syscall.h>
+diff --git a/libcxx/src/atomic.cpp b/libcxx/src/atomic.cpp
+index b214ba1fd..43eb0ebc9 100644
+--- a/src/atomic.cpp
++++ b/src/atomic.cpp
+@@ -25,14 +25,14 @@
+ #  if !defined(SYS_futex) && defined(SYS_futex_time64)
+ #    define SYS_futex SYS_futex_time64
+ #  endif
+-#  define _LIBCPP_FUTEX(...) syscall(SYS_futex, __VA_ARGS__)
++#  define _LIBCPP_FUTEX(...) uk_syscall(SYS_futex, __VA_ARGS__)
  
- // libc++ uses SYS_futex as a universal syscall name. However, on 32 bit architectures
- // with a 64 bit time_t, we need to specify SYS_futex_time64.
-@@ -45,13 +46,13 @@
-                                               __cxx_contention_t __val)
- {
-     static constexpr timespec __timeout = { 2, 0 };
--    syscall(SYS_futex, __ptr, FUTEX_WAIT_PRIVATE, __val, &__timeout, 0, 0);
-+    uk_syscall_static(SYS_futex, __ptr, FUTEX_WAIT_PRIVATE, __val, &__timeout, 0, 0);
- }
+ #elif defined(__FreeBSD__)
  
- static void __libcpp_platform_wake_by_address(__cxx_atomic_contention_t const volatile* __ptr,
-                                               bool __notify_one)
- {
--    syscall(SYS_futex, __ptr, FUTEX_WAKE_PRIVATE, __notify_one ? 1 : INT_MAX, 0, 0, 0);
-+    uk_syscall_static(SYS_futex, __ptr, FUTEX_WAKE_PRIVATE, __notify_one ? 1 : INT_MAX, 0, 0, 0);
- }
+ #  include <sys/types.h>
+ #  include <sys/umtx.h>
  
- #elif defined(__APPLE__) && defined(_LIBCPP_USE_ULOCK)
+-#  define _LIBCPP_FUTEX(...) syscall(SYS_futex, __VA_ARGS__)
++#  define _LIBCPP_FUTEX(...) uk_syscall(SYS_futex, __VA_ARGS__)
+ 
+ #elif defined(__OpenBSD__)
+ 
+@@ -45,7 +45,7 @@
+ 
+ // Baseline needs no new headers
+ 
+-#  define _LIBCPP_FUTEX(...) syscall(SYS_futex, __VA_ARGS__)
++#  define _LIBCPP_FUTEX(...) uk_syscall(SYS_futex, __VA_ARGS__)
+ 
+ #endif
+ 

--- a/patches/0001-Use-__is_convertible-built-in-when-available.patch
+++ b/patches/0001-Use-__is_convertible-built-in-when-available.patch
@@ -1,24 +1,32 @@
-diff --git a/libcxx/include/type_traits b/libcxx/include/type_traits
-index 3391999675..ab126d000d 100644
---- a/include/type_traits
-+++ b/include/type_traits
-@@ -1659,11 +1659,18 @@ struct __is_core_convertible<_Tp, _Up, decltype(
+diff --git a/include/__type_traits/is_convertible.h b/include/__type_traits/is_convertible.h
+index f0a859f9c..222d8a826 100644
+--- a/include/__type_traits/is_convertible.h
++++ b/include/__type_traits/is_convertible.h
+@@ -18,6 +18,8 @@
  
- // is_convertible
+ _LIBCPP_BEGIN_NAMESPACE_STD
  
--#if __has_feature(is_convertible_to) && !defined(_LIBCPP_USE_IS_CONVERTIBLE_FALLBACK)
 +#if __has_builtin(__is_convertible) && !defined(_LIBCPP_USE_IS_CONVERTIBLE_FALLBACK)
 +
-+template <class _T1, class _T2>
-+struct _LIBCPP_TEMPLATE_VIS is_convertible : public integral_constant<bool, __is_convertible(_T1, _T2)> {};
-+
+ template <class _T1, class _T2>
+ struct _LIBCPP_NO_SPECIALIZATIONS is_convertible : integral_constant<bool, __is_convertible(_T1, _T2)> {};
+ 
+@@ -26,6 +28,18 @@ template <class _From, class _To>
+ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_convertible_v = __is_convertible(_From, _To);
+ #endif
+ 
 +#elif __has_feature(is_convertible_to) && !defined(_LIBCPP_USE_IS_CONVERTIBLE_FALLBACK)
++
++template <class _T1, class _T2>
++struct _LIBCPP_NO_SPECIALIZATIONS is_convertible : integral_constant<bool, __is_convertible_to(_T1, _T2)> {};
++
++#if _LIBCPP_STD_VER >= 17
++template <class _From, class _To>
++_LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_convertible_v = __is_convertible_to(_From, _To);
++#endif
++
++#endif
++
+ #if _LIBCPP_STD_VER >= 20
  
- template <class _T1, class _T2> struct _LIBCPP_TEMPLATE_VIS is_convertible
-     : public integral_constant<bool, __is_convertible_to(_T1, _T2)> {};
- 
-+// TODO: Remove this fallback when GCC < 13 support is no longer required.
-+// GCC 13 has the __is_convertible built-in.
- #else  // __has_feature(is_convertible_to)
- 
- namespace __is_convertible_imp
+ template <class _Tp, class _Up>


### PR DESCRIPTION
Update to lib-libcxx version 21.1.1

This PR is a part of a set of PRs:

- [lib-libcxx#37](https://github.com/unikraft/lib-libcxx/pull/37)
- [lib-libcxxabi#7](https://github.com/unikraft/lib-libcxxabi/pull/7)
- [lib-libunwind#12](https://github.com/unikraft/lib-libunwind/pull/12)
- [lib-compiler-rt#21](https://github.com/unikraft/lib-compiler-rt/pull/21)

Tested with `gcc 15.2.0` and `clang 19.1.4`